### PR TITLE
Fix Swordfish UNITYPEs by adding Gunship

### DIFF
--- a/pa/units/addon/swordfish/swordfish.json
+++ b/pa/units/addon/swordfish/swordfish.json
@@ -6,6 +6,7 @@
     "max_health": 150,
     "build_metal_cost": 400,
     "unit_types": [
+        "UNITTYPE_Gunship",
         "UNITTYPE_Mobile",
         "UNITTYPE_Offense",
         "UNITTYPE_Air",


### PR DESCRIPTION
It's an anti-ground unit so either needs a Gunship or Bomber label. As it's a T1 Strafer I went with Gunship. This ensures enemy unit target priorities work correctly and the AI understands how to use it in its platoons.