### PR TITLE
Cleaner AI implementation of Swordfish

### DIFF
--- a/pa/ai/factory_builds/factory_air_builds_mua.json
+++ b/pa/ai/factory_builds/factory_air_builds_mua.json
@@ -37,15 +37,6 @@
             "compare0": ">",
             "value0": 0
           }
-        ],
-        [
-          {
-            "test_type": "CanAffordBuildDemand"
-          },
-          {
-            "test_type": "EnemyAirPresenceOnPlanet",
-            "boolean": true
-          }
         ]
       ]
     }

--- a/pa/ai/factory_builds/factory_air_builds_mua.json
+++ b/pa/ai/factory_builds/factory_air_builds_mua.json
@@ -6,21 +6,21 @@
       "instance_count": -1,
       "max_num_assisters": 10,
       "priority": 97,
-      "builders": [
-        "BasicAirFactory"
-      ],
+      "builders": ["BasicAirFactory"],
       "build_conditions": [
         [
           {
             "test_type": "CanAffordBuildDemand"
           },
           {
-            "test_type": "EnemySurfacePresenceOnPlanet",
-            "boolean": true
+            "test_type": "AloneOnPlanet",
+            "boolean": false
           },
           {
-            "test_type": "CanDeployNavalFromBase",
-            "boolean": true
+            "test_type": "PlanetHighestEnemyArmyThreat",
+            "string0": "Naval",
+            "compare0": ">",
+            "value0": 0
           }
         ],
         [
@@ -33,9 +33,18 @@
           },
           {
             "test_type": "PlanetHighestEnemyArmyThreat",
-            "string0": "Air",
+            "string0": "Sub",
             "compare0": ">",
             "value0": 0
+          }
+        ],
+        [
+          {
+            "test_type": "CanAffordBuildDemand"
+          },
+          {
+            "test_type": "EnemyAirPresenceOnPlanet",
+            "boolean": true
           }
         ]
       ]


### PR DESCRIPTION
My assumption is that the previous changes were meant to be, build Swordfish if:

1. the enemy has naval; or
2. the enemy has air.

The Swordfish can't actually shoot air right now, so I'm confused by its target priorities and the addition of this build condition. If it's designed to be primarily anti-air and not anti-ground, you need to change UNITTYPE_Gunship to UNITTYPE_Fighter. Or you could use both tags and let the AI switch it between roles.