### PR TITLE
Add server dependency to modinfo

### DIFF
--- a/modinfo.json
+++ b/modinfo.json
@@ -21,6 +21,6 @@
 	"date": "2022-01-14",
 	"build": "115958",
 	"version": "1.1.5",
-	"dependencies": [],
+	"dependencies": ["pa.mla.unit.addon"],
 	"hidden": true
 }


### PR DESCRIPTION
Ensures that when the server component is disabled or uninstalled, that the hidden client component is too.