### PR TITLE
Fix invalid layer for radar jammer on Stalker

### DIFF
--- a/pa/units/addon/stalker/stalker.json
+++ b/pa/units/addon/stalker/stalker.json
@@ -59,7 +59,7 @@
                     "radius": 140
                 },
                 {
-                    "layer": "surface",
+                    "layer": "surface_and_air",
                     "channel": "radar_jammer",
                     "shape": "capsule",
                     "radius": 15,


### PR DESCRIPTION
Noted in the server logs:

ERROR reconItemLayerFromString encountered unknown value: [surface]